### PR TITLE
fix: alterando verbo http de delete para post

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -9,5 +9,5 @@ func RegisterRouter(e *echo.Echo, rm *application.ReceiverManagement) {
 	e.GET("/list", ListReceiver(rm))
 	e.POST("/create", CreateReceiver(rm))
 	e.PATCH("/update", UpdateReceiver(rm))
-	e.DELETE("/delete", DeleteReceiver(rm))
+	e.POST("/delete", DeleteReceiver(rm))
 }

--- a/internal/test/integration/delete_receiver_test.go
+++ b/internal/test/integration/delete_receiver_test.go
@@ -19,7 +19,7 @@ func (s *IntegrationSuite) TestDeleteReceiverIntegrationSuccess() {
 
 	reqBody, _ := json.Marshal(params)
 
-	resp := s.Request("DELETE", "/delete", reqBody)
+	resp := s.Request("POST", "/delete", reqBody)
 
 	assert.Equal(t, 204, resp.StatusCode)
 


### PR DESCRIPTION
De acordo com a RFC 9910: HTTP-Semantics: https://www.rfc-editor.org/rfc/rfc9110.html#DELETE
Verbos delete não devem ter envio de body, então o verbo http utilizado foi alterado de DELETE para POST